### PR TITLE
Enabled the admin dashboard page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,9 @@
 class HomeController < ApplicationController
-  def index; end
+  def index
+    @hope = 'Hope is the anchor of the soul'
+    @brokers = User.where(type: 'Broker')
+    @buyers = User.where(type: 'Buyer')
+  end
 
   def portfolio; end
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -11,3 +11,32 @@
   <%= current_buyer.first_name %><br/>
   <%= current_buyer.last_name %><br/>
 <% end %>
+
+<% if admin_signed_in? %>
+  <p>admin dashboard page</p>
+  <h1><%= @hope %></h1>
+  <br/>
+  <div class="row">
+    <div class="col-md-6">
+      <h2>buyer count: <%= @buyers.count %></h2>
+      <% @buyers.each do |buyer| %>
+        <p><%= buyer.email %></p>
+        <p><%= buyer.first_name %></p>
+        <p><%= buyer.last_name %></p>
+        <h3>Status: pending</h3>
+        <hr/>
+      <% end %>
+    </div>
+    <div class="col-md-6">
+      <h2>broker count: <%= @brokers.count %></h2>
+      <% @brokers.each do |brokers| %>
+        <p><%= brokers.email %></p>
+        <p><%= brokers.first_name %></p>
+        <p><%= brokers.last_name %></p>
+        <h3>Status: pending</h3>
+        <hr/>
+      <% end %>
+    </div>
+  </div>
+  
+<% end %>

--- a/app/views/home/portfolio.html.erb
+++ b/app/views/home/portfolio.html.erb
@@ -38,7 +38,7 @@
       </tr>
     </thead>
     <tbody>      
-      <% current_buyer.buyerStocks.each do |stock| %>
+      <% current_buyer.buyer_stocks.each do |stock| %>
         <tr>
           <th scope="row"><%= current_buyer.id %></th>
           <td><%= stock.price %></td>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -41,7 +41,14 @@
           <li>
             buyer
           </li>
-        <% else %>  
+        <% elsif admin_signed_in? %>
+          <li class="nav-item">
+            <%= link_to "Portfolio", portfolio_home_index_path, class: "nav-link" %>
+          </li>   
+          <li class="nav-item">
+            <%= button_to "admin Sign out", destroy_admin_session_path , protocol: 'https', method: :delete, class: "nav-link" %>
+          </li>                   
+        <% else %>
           <li class="nav-item">
             <%= link_to "broker Sign up", new_broker_registration_path, class: "nav-link" %>
           </li>
@@ -53,7 +60,7 @@
           </li>
           <li class="nav-item">
             <%= button_to "buyer Sign in", buyer_session_path, class: "nav-link" %>
-          </li>          
+          </li>
         <% end %>
       </ul>
     </div>


### PR DESCRIPTION
## Pull Request
#### Added simple admin feature

[WIP] Other admin features like approve and reject buttons for newly created broker accounts.

## The Story
In this project, I realized that the admin dashboard page is very important to be implemented early on since that is the place where an admin can approve or reject a broker to conduct business in the app, that is why I started to build a simple admin dashboard. It only displays all buyers and brokers for now. Here is what I did in the PR.

- Enabled the sign in and sign out functionality for admin.
- Implemented an admin dashboard that displays all buyers and brokers.
- Restructured the navigation bar to accommodate the added buttons.

## Screenshots
#### Admin sign in page
![image](https://user-images.githubusercontent.com/35893311/122641452-7d12e800-d0d3-11eb-8cf7-96839bec7ccb.png)
#### Admin dashboard page and admin sign out button
![image](https://user-images.githubusercontent.com/35893311/122641461-9451d580-d0d3-11eb-8689-e8bb98e3fae1.png)

## Resources
https://dev.to/luchiago/multiple-foreign-keys-for-the-same-model-in-rails-6-7ml
http://www.adwaretech.com/blog/rails-migrations-in-a-nutshell